### PR TITLE
fix get_asn_info when there is no modified date

### DIFF
--- a/lib/Net/Abuse/Utils.pm
+++ b/lib/Net/Abuse/Utils.pm
@@ -141,7 +141,7 @@ sub get_all_asn_info {
     # 23028 | 216.90.108.0/24 | US | arin | 1998-09-25
     # 701 1239 3549 3561 7132 | 216.90.108.0/24 | US | arin | 1998-09-25
     for my $asinfo (@$data) {
-        $asinfo = { data => [ split m/ \| /, $asinfo ] };
+        $asinfo = { data => [ split m/ ?\| ?/, $asinfo ] };
         $asinfo->{length} = ( split m|/|, $asinfo->{data}[1] )[1];
     }
     $data = [ map { $_->{data} }

--- a/t/Net-Abuse-Utils-offline.t
+++ b/t/Net-Abuse-Utils-offline.t
@@ -1,3 +1,6 @@
+BEGIN { chdir 't' if -d 't' }
+use lib '../lib';
+
 use Test::More;
 BEGIN { use_ok('Net::Abuse::Utils') }
 

--- a/t/Net-Abuse-Utils.t
+++ b/t/Net-Abuse-Utils.t
@@ -50,4 +50,11 @@ $ip = '216.87.155.0';
 ok(get_asn_info($ip), 'get_asn_info with multiple results..');
 ok(get_peer_info($ip), 'get_peer_info with multiple results..');
 
+$ip = '18.0.0.0';
+# no modification time:
+# dig +short 0.0.0.18.origin.asn.cymru.com TXT
+# "3 | 18.0.0.0/8 | US | arin |"
+my @result = get_asn_info( $ip );
+is( $result[3], 'arin', "${ip} has RIR 'arin' and not 'arin |'" );
+
 done_testing;

--- a/t/Net-Abuse-Utils.t
+++ b/t/Net-Abuse-Utils.t
@@ -1,3 +1,6 @@
+BEGIN { chdir 't' if -d 't' }
+use lib '../lib';
+
 BEGIN {
     unless ($ENV{RELEASE_TESTING} || $ENV{ONLINE_TESTS}) {
         require Test::More;

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,3 +1,6 @@
+BEGIN { chdir 't' if -d 't' }
+use lib '../lib';
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 plan skip_all => "Test::Pod::Coverage 1.00 required for testing POD coverage" if $@;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,3 +1,6 @@
+BEGIN { chdir '..' if not -d 't' }
+use lib 'lib';
+
 use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;


### PR DESCRIPTION
get_asn_info would report an incorrect RIR if there was no modified date.  A trailing ' |' was added.