### PR TITLE
Do not depend on insecure module Email::Address

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,7 +38,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Email::Address" : "0",
+            "Email::Address::XS" : "0",
             "Net::DNS" : "0",
             "Net::IP" : "0",
             "Net::Whois::IP" : "1.11",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.006",
   "NAME" => "Net::Abuse::Utils",
   "PREREQ_PM" => {
-    "Email::Address" => 0,
+    "Email::Address::XS" => 0,
     "Net::DNS" => 0,
     "Net::IP" => 0,
     "Net::Whois::IP" => "1.11"
@@ -34,7 +34,7 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "Email::Address" => 0,
+  "Email::Address::XS" => 0,
   "ExtUtils::MakeMaker" => 0,
   "Net::DNS" => 0,
   "Net::IP" => 0,

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ may be made available in the future via an import flag to use.
 
 This module makes use of the following modules:
 
-[Net::IP](https://metacpan.org/pod/Net::IP), [Net::DNS](https://metacpan.org/pod/Net::DNS), [Net::Whois::IP](https://metacpan.org/pod/Net::Whois::IP), and [Email::Address](https://metacpan.org/pod/Email::Address)
+[Net::IP](https://metacpan.org/pod/Net::IP), [Net::DNS](https://metacpan.org/pod/Net::DNS), [Net::Whois::IP](https://metacpan.org/pod/Net::Whois::IP), and [Email::Address::XS](https://metacpan.org/pod/Email::Address::XS)
 
 # BUGS AND LIMITATIONS
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'perl', '5.006';
-requires 'Email::Address';
+requires 'Email::Address::XS';
 requires 'Net::DNS';
 requires 'Net::Whois::IP', 1.11;
 requires 'Net::IP';

--- a/lib/Net/Abuse/Utils.pm
+++ b/lib/Net/Abuse/Utils.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Net::DNS;
 use Net::Whois::IP 1.11 'whoisip_query';
-use Email::Address;
+use Email::Address::XS;
 use Net::IP;
 # use Memoize;
 
@@ -119,10 +119,10 @@ sub get_ipwi_contacts {
 
     my @fields = exists $response->{'abuse-mailbox'} ? ( 'abuse-mailbox' ) : keys %$response;
     foreach my $field (@fields) {
-        push @addresses, Email::Address->parse($response->{$field});
+        push @addresses, Email::Address::XS->parse($response->{$field});
     }
 
-    @addresses = map { $_->address } @addresses;
+    @addresses = grep { defined $_ } map { $_->address } @addresses;
     return _return_unique (\@addresses);
 }
 
@@ -458,7 +458,7 @@ may be made available in the future via an import flag to use.
 
 This module makes use of the following modules:
 
-L<Net::IP>, L<Net::DNS>, L<Net::Whois::IP>, and L<Email::Address>
+L<Net::IP>, L<Net::DNS>, L<Net::Whois::IP>, and L<Email::Address::XS>
 
 =head1 BUGS AND LIMITATIONS
 


### PR DESCRIPTION
Module Email::Address is vulnerable to CVE-2015-7686 and new replacement is
module Email::Address::XS.